### PR TITLE
Add "split every wave" functionality for adventure mode

### DIFF
--- a/PlantsVsZombies.asl
+++ b/PlantsVsZombies.asl
@@ -124,8 +124,14 @@ start{
 
 split{
 	// split every advenlevel in Adventure mode
-	if (current.levelID == 0)
+	if (current.levelID == 0) {
+		
+		// split every wave
+		if (settings["wave"] && (current.UI == 3 && current.currentWave != old.currentWave) )
+			return true;
+
 		return current.advenlevel != old.advenlevel;
+	}
 	else {
 		// split when returing to main menu
 		if (old.UI == 3 && (current.UI == 5 || current.UI == 7) )


### PR DESCRIPTION
I've been finding this very helpful to see where I've been having slow waves when practicing.